### PR TITLE
adding __slots__

### DIFF
--- a/mrtparse.py
+++ b/mrtparse.py
@@ -469,7 +469,7 @@ class Base:
         return rd
 
 class Reader(Base):
-    __slots__ = ['as_rep', 'buf', 'len', 'mrt']
+    __slots__ = ['as_rep', 'buf', 'len', 'mrt', 'f']
 
     def __init__(self, arg):
         Base.__init__(self)

--- a/mrtparse.py
+++ b/mrtparse.py
@@ -398,6 +398,8 @@ as_rep = AS_REP['asplain']
 
 # super class for all other classes
 class Base:
+    __slots__ = ['p']
+
     def __init__(self):
         self.p = 0
 
@@ -467,6 +469,8 @@ class Base:
         return rd
 
 class Reader(Base):
+    __slots__ = ['as_rep', 'buf', 'len', 'mrt']
+
     def __init__(self, arg):
         Base.__init__(self)
         self.as_rep = as_rep
@@ -563,6 +567,10 @@ class Reader(Base):
             self.p += self.len
 
 class Mrt(Base):
+    __slots__ = ['ts', 'type', 'subtype', 'len', 'view', 'seq', 'prefix',
+                 'plen', 'status', 'org_time', 'peer_ip', 'peer_as', 'attr',
+                 'micro_ts', 'peer', 'td', 'bgp', 'rib']
+
     def __init__(self):
         Base.__init__(self)
         self.ts = None
@@ -593,6 +601,9 @@ class Mrt(Base):
         return self.p
 
 class TableDump(Base):
+    __slots__ = ['view', 'seq', 'prefix', 'plen', 'status', 'org_time',
+                 'peer_ip', 'peer_as', 'attr', 'attr_len']
+
     def __init__(self):
         Base.__init__(self)
         self.view = None
@@ -627,6 +638,8 @@ class TableDump(Base):
         return self.p
 
 class PeerIndexTable(Base):
+    __slots__ = ['collector', 'view_len', 'view', 'count', 'entry']
+
     def __init__(self):
         Base.__init__(self)
         self.collector = None
@@ -648,6 +661,8 @@ class PeerIndexTable(Base):
         return self.p
 
 class PeerEntries(Base):
+    __slots__ = ['type', 'bgp_id', 'ip', 'asn']
+
     def __init__(self):
         Base.__init__(self)
         self.type = None
@@ -668,6 +683,8 @@ class PeerEntries(Base):
         return self.p
 
 class AfiSpecRib(Base):
+    __slots__ = ['seq', 'plen', 'prefix', 'count', 'entry']
+
     def __init__(self):
         Base.__init__(self)
         self.seq = None
@@ -689,6 +706,8 @@ class AfiSpecRib(Base):
         return self.p
 
 class RibEntries(Base):
+    __slots__ = ['peer_index', 'org_time', 'attr', 'attr_len']
+
     def __init__(self):
         Base.__init__(self)
         self.peer_index = None
@@ -711,6 +730,9 @@ class RibEntries(Base):
         return self.p
 
 class Bgp4Mp(Base):
+    __slots__ = ['peer_as', 'local_as', 'ifindex', 'af', 'peer_ip', 'local_ip',
+                 'old_state', 'new_state', 'msg']
+
     def __init__(self):
         Base.__init__(self)
         self.peer_as = None
@@ -751,6 +773,11 @@ class Bgp4Mp(Base):
         return self.p
 
 class BgpMessage(Base):
+    __slots__ = ['marker', 'len', 'type', 'ver', 'my_as', 'holdtime', 'bgp_id',
+                 'bgp_id', 'opt_params', 'opt_len', 'wd_len', 'attr',
+                 'attr_len', 'withdrawn', 'nlri', 'err_code', 'err_subcode',
+                 'data', 'afi', 'rsvd', 'safi']
+
     def __init__(self):
         Base.__init__(self)
         self.marker = None
@@ -838,6 +865,9 @@ class BgpMessage(Base):
         self.safi = self.val_num(buf, 1)
 
 class OptParams(Base):
+    __slots__ = ['type', 'len', 'cap_type', 'cap_len', 'multi_ext', 'orf',
+                 'graceful_restart', 'support_as4']
+
     def __init__(self):
         Base.__init__(self)
         self.type = None
@@ -913,6 +943,11 @@ class OptParams(Base):
         self.support_as4 = self.val_asn(buf, 4)
 
 class BgpAttr(Base):
+    __slots__ = ['flag', 'type', 'len', 'val', 'origin', 'as_path', 'next_hop',
+                 'med', 'local_pref', 'aggr', 'comm', 'org_id', 'cl_list',
+                 'mp_reach', 'mp_unreach', 'ext_comm', 'as4_path', 'as4_aggr',
+                 'aigp', 'attr_set']
+
     def __init__(self):
         Base.__init__(self)
         self.flag = None
@@ -1147,6 +1182,8 @@ class BgpAttr(Base):
             self.attr_set['attr'].append(attr)
 
 class Nlri(Base):
+    __slots__ = ['prefix', 'label', 'rd', 'plen']
+
     def __init__(self):
         Base.__init__(self)
         self.prefix = None

--- a/mrtparse.py
+++ b/mrtparse.py
@@ -470,6 +470,9 @@ class Reader(Base):
     def __init__(self, arg):
         Base.__init__(self)
         self.as_rep = as_rep
+        self.buf = None
+        self.len = None
+        self.mrt = None
 
         # for file instance
         if hasattr(arg, 'read'):
@@ -562,6 +565,25 @@ class Reader(Base):
 class Mrt(Base):
     def __init__(self):
         Base.__init__(self)
+        self.ts = None
+        self.type = None
+        self.subtype = None
+        self.len = None
+        self.view = None
+        self.seq = None
+        self.prefix = None
+        self.plen = None
+        self.status = None
+        self.org_time = None
+        self.peer_ip = None
+        self.peer_as = None
+        self.attr = None
+        self.micro_ts = None
+        self.peer = None
+        self.td = None
+        self.bgp = None
+        self.rib = None
+
 
     def unpack(self, buf):
         self.ts = self.val_num(buf, 4)
@@ -573,6 +595,16 @@ class Mrt(Base):
 class TableDump(Base):
     def __init__(self):
         Base.__init__(self)
+        self.view = None
+        self.seq = None
+        self.prefix = None
+        self.plen = None
+        self.status = None
+        self.org_time = None
+        self.peer_ip = None
+        self.peer_as = None
+        self.attr = None
+        self.attr_len = None
 
     def unpack(self, buf, subtype):
         global as_len
@@ -597,6 +629,11 @@ class TableDump(Base):
 class PeerIndexTable(Base):
     def __init__(self):
         Base.__init__(self)
+        self.collector = None
+        self.view_len = None
+        self.view = None
+        self.count = None
+        self.entry = None
 
     def unpack(self, buf):
         self.collector = self.val_addr(buf, AFI_T['IPv4'])
@@ -613,6 +650,10 @@ class PeerIndexTable(Base):
 class PeerEntries(Base):
     def __init__(self):
         Base.__init__(self)
+        self.type = None
+        self.bgp_id = None
+        self.ip = None
+        self.asn = None
 
     def unpack(self, buf):
         self.type = self.val_num(buf, 1)
@@ -629,6 +670,11 @@ class PeerEntries(Base):
 class AfiSpecRib(Base):
     def __init__(self):
         Base.__init__(self)
+        self.seq = None
+        self.plen = None
+        self.prefix = None
+        self.count = None
+        self.entry = None
 
     def unpack(self, buf, af):
         self.seq = self.val_num(buf, 4)
@@ -645,6 +691,11 @@ class AfiSpecRib(Base):
 class RibEntries(Base):
     def __init__(self):
         Base.__init__(self)
+        self.peer_index = None
+        self.org_time = None
+        self.attr = None
+        self.attr_len = None
+
 
     def unpack(self, buf):
         self.peer_index = self.val_num(buf, 2)
@@ -662,6 +713,15 @@ class RibEntries(Base):
 class Bgp4Mp(Base):
     def __init__(self):
         Base.__init__(self)
+        self.peer_as = None
+        self.local_as = None
+        self.ifindex = None
+        self.af = None
+        self.peer_ip = None
+        self.local_ip = None
+        self.old_state = None
+        self.new_state = None
+        self.msg = None
 
     def unpack(self, buf, subtype):
         global as_len
@@ -693,6 +753,26 @@ class Bgp4Mp(Base):
 class BgpMessage(Base):
     def __init__(self):
         Base.__init__(self)
+        self.marker = None
+        self.len = None
+        self.type = None
+        self.ver = None
+        self.my_as = None
+        self.holdtime = None
+        self.bgp_id = None
+        self.opt_params = None
+        self.opt_len = None
+        self.wd_len = None
+        self.attr = None
+        self.attr_len = None
+        self.withdrawn = None
+        self.nlri = None
+        self.err_code = None
+        self.err_subcode = None
+        self.data = None
+        self.afi = None
+        self.rsvd = None
+        self.safi = None
 
     def unpack(self, buf, af):
         self.marker = self.val_str(buf, 16)
@@ -760,6 +840,14 @@ class BgpMessage(Base):
 class OptParams(Base):
     def __init__(self):
         Base.__init__(self)
+        self.type = None
+        self.len = None
+        self.cap_type = None
+        self.cap_len = None
+        self.multi_ext = None
+        self.orf = None
+        self.graceful_restart = None
+        self.support_as4 = None
 
     def unpack(self, buf):
         self.type = self.val_num(buf, 1)
@@ -827,6 +915,26 @@ class OptParams(Base):
 class BgpAttr(Base):
     def __init__(self):
         Base.__init__(self)
+        self.flag = None
+        self.type = None
+        self.len = None
+        self.val = None
+        self.origin = None
+        self.as_path = None
+        self.next_hop = None
+        self.med = None
+        self.local_pref = None
+        self.aggr = None
+        self.comm = None
+        self.org_id = None
+        self.cl_list = None
+        self.mp_reach = None
+        self.mp_unreach = None
+        self.ext_comm = None
+        self.as4_path = None
+        self.as4_aggr = None
+        self.aigp = None
+        self.attr_set = None
 
     def unpack(self, buf):
         self.flag = self.val_num(buf, 1)
@@ -1041,6 +1149,10 @@ class BgpAttr(Base):
 class Nlri(Base):
     def __init__(self):
         Base.__init__(self)
+        self.prefix = None
+        self.label = None
+        self.rd = None
+        self.plen = None
 
     def unpack(self, buf, *args):
         af = args[0]


### PR DESCRIPTION
Since you maybe iterate over thousands of messages in a dump it is a good idea to add `__slots__` for a better memory consumption and performance.

It seems to save about 5 - 9% time:

```
/usr/bin/time python3 examples/print_all.py ~/Downloads/rib.20150101.0400.bz2
238.09user 63.81system 5:59.71elapsed 83%CPU (0avgtext+0avgdata 14236maxresident)k
64inputs+0outputs (0major+18652minor)pagefaults 0swaps
```

```
/usr/bin/time python3 examples/print_all.py ~/Downloads/rib.20150101.0400.bz2
220.48user 60.77system 5:37.79elapsed 83%CPU (0avgtext+0avgdata 14228maxresident)k
15056inputs+0outputs (16major+18640minor)pagefaults 0swaps
```
