### PR TITLE
Replace the ugly dicts with Enumerations (Create misssing enums on request)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Table_Dump(12), Table_Dump_V2(13), BGP4MP(16), BGP4MP_ET(17)
 ORIGIN(1), AS_PATH(2), NEXT_HOP(3), MULTI_EXIT_DISC(4), LOCAL_PREF(5), ATOMIC_AGGREGATE(6), AGGREGATOR(7), COMMUNITY(8), ORIGINATOR_ID(9), CLUSTER_LIST(10), MP_REACH_NLRI(14), MP_UNREACH_NLRI(15), EXTENDED_COMMUNITIES(16), AS4_PATH(17), AS4_AGGREGATOR(18), AIGP(26), ATTR_SET(128)
 
 ##Requirements
-Python2 or Python3 or PyPy
+ + Python2 or Python3 or PyPy
+ + `enum` module (either built in since Python3.4 or the backported version [`enum34`](https://pypi.python.org/pypi/enum34))
 
 ##Download
 ###git command

--- a/mrtparse.py
+++ b/mrtparse.py
@@ -37,7 +37,7 @@ __url__     = 'https://github.com/YoshiyukiYamauchi/mrtparse'
 __author__  = 'Tetsumune KISO, Yoshiyuki YAMAUCHI, Nobuhiro ITOU'
 __email__   = 't2mune@gmail.com, info@greenhippo.co.jp, js333123@gmail.com'
 __license__ = 'Apache License, Version 2.0'
-__all__     = (['Reader'] +
+__all__     = (['Reader', 'val_dict'] +
                ['AFI_T', 'SAFI_T', 'MSG_T', 'BGP_ST', 'TD_ST', 'TD_V2_ST',
                 'BGP4MP_ST', 'MSG_ST', 'BGP_FSM', 'BGP_ATTR_T', 'ORIGIN_T',
                 'AS_PATH_SEG_T', 'COMM_T', 'BGP_MSG_T', 'BGP_ERR_C',

--- a/mrtparse.py
+++ b/mrtparse.py
@@ -127,9 +127,12 @@ class _BaseEnum(int, enum.Enum):
         return obj
 
     def __str__(self):
-        return (str(self.value) +
-                " (" + str(getattr(self, 'nice', self.name)) + ")"
-                )
+        nice_str = getattr(self, 'nice', None)
+        if nice_str is not None:
+            name = nice_str
+        else:
+            name = self.name
+        return (str(self.value) + " (" + str(name) + ")")
 
     def __repr__(self):
         nice_str = getattr(self, 'nice', None)

--- a/mrtparse.py
+++ b/mrtparse.py
@@ -58,7 +58,7 @@ BZ2_MAGIC  = b'\x42\x5a\x68'
 # MRT header length
 MRT_HDR_LEN = 12
 
-class FillEnum(object):
+class _FillEnum(object):
 
     """This Decorator returns an Enum, which contains all values in `values`.
 
@@ -108,7 +108,7 @@ class FillEnum(object):
 
         return new_enum_cls
 
-class BaseEnum(int, enum.Enum):
+class _BaseEnum(int, enum.Enum):
     """This class is the abstract Base for Type and Code Enums here.
 
     It Provides a customized __str__ and __repr__ string prints.
@@ -152,7 +152,7 @@ AFI_T = {
 dl += [AFI_T]
 
 @enum.unique
-class AfiT(BaseEnum):
+class AfiT(_BaseEnum):
     """AFI Types. Assigend by IANA"""
     ipv4 = 1
     ipv6 = 2
@@ -169,7 +169,7 @@ SAFI_T = {
 dl += [SAFI_T]
 
 @enum.unique
-class SafiT(BaseEnum):
+class SafiT(_BaseEnum):
     """SAFI Types. Assigend by IANA"""
     unicast = 1
     multicast = 2
@@ -206,7 +206,7 @@ dl += [MSG_T]
 @enum.unique
 # The field has a length of 16bit. However we only use here 8bit for faster
 # class level initialization until we need more bits.
-@FillEnum(BaseEnum, range(2**8), prefix='val', module=__name__)
+@_FillEnum(_BaseEnum, range(2**8), prefix='val', module=__name__)
 class MsgT(object):
     """MRT Message Types. Defined in RFC6396."""
     null = 0           # Deprecated in RFC6396
@@ -246,7 +246,7 @@ BGP_ST = {
 dl += [BGP_ST]
 
 @enum.unique
-class BgpSt(BaseEnum):
+class BgpSt(_BaseEnum):
     """BGP,BGP4PLUS,BGP4PLUS_01 Subtypes. Deprecated in RFC6396."""
     bgp_null = 0
     bgp_update = 1
@@ -267,7 +267,7 @@ TD_ST = {
 dl += [AFI_T]
 
 @enum.unique
-class TdSt(BaseEnum):
+class TdSt(_BaseEnum):
     """TABLE_DUMP Subtypes. Defined in RFC6396."""
     afi_ipv4 = 1
     afi_ipv6 = 2
@@ -286,7 +286,7 @@ TD_V2_ST = {
 dl += [TD_V2_ST]
 
 @enum.unique
-class TdV2St(BaseEnum):
+class TdV2St(_BaseEnum):
     """TABLE_DUMP_V2 Subtypes. Defined in RFC6396."""
     peer_index_table = 1
     rib_ipv4_unicast = 2
@@ -311,7 +311,7 @@ BGP4MP_ST = {
 dl += [BGP4MP_ST]
 
 @enum.unique
-class Bgp4mpSt(BaseEnum):
+class Bgp4mpSt(_BaseEnum):
     """BGP4MP,BGP4MP_ET Subtypes. Defined in RFC6396."""
     bgp4mp_state_change = 0
     bgp4mp_message = 1
@@ -337,7 +337,7 @@ MSG_ST = {
 @enum.unique
 # The field has a length of 16bit. However we only use here 8bit for faster
 # class level initialization until we need more bits.
-@FillEnum(BaseEnum, range(2**8), prefix='val', module=__name__)
+@_FillEnum(_BaseEnum, range(2**8), prefix='val', module=__name__)
 class MsgSt(object):
     """MRT Message Subtypes. Defined in RFC6396."""
     bgp_st9 = 9
@@ -369,7 +369,7 @@ BGP_FSM = {
 dl += [BGP_FSM]
 
 @enum.unique
-class BgpFsm(BaseEnum):
+class BgpFsm(_BaseEnum):
     """BGP FSM States. Defined in RFC4271."""
     idle = 1
     connect = 2
@@ -409,7 +409,7 @@ BGP_ATTR_T = {
 dl += [BGP_ATTR_T]
 
 @enum.unique
-class BgpAttrT(BaseEnum):
+class BgpAttrT(_BaseEnum):
     """BGP Attribute Types. Defined in RFC4271 and others."""
     reserved = 0
     origin = 1
@@ -465,7 +465,7 @@ ORIGIN_T = {
 dl += [ORIGIN_T]
 
 @enum.unique
-class OriginT(BaseEnum):
+class OriginT(_BaseEnum):
     """BGP ORIGIN Types. Defined in RFC4271."""
     igp = 0
     egp = 1
@@ -483,7 +483,7 @@ AS_PATH_SEG_T = {
 dl += [AS_PATH_SEG_T]
 
 @enum.unique
-class AsPathSegT(BaseEnum):
+class AsPathSegT(_BaseEnum):
     """BGP AS_PATH Types. Defined in RFC4271."""
     as_set = 1
     as_sequence = 2
@@ -502,7 +502,7 @@ COMM_T = {
 dl += [COMM_T]
 
 @enum.unique
-class CommT(BaseEnum):
+class CommT(_BaseEnum):
     """Reserved BGP COMMUNITY Types. Defined in RFC1997."""
     no_export = 0xffffff01
     no_advertise = 0xffffff02
@@ -530,7 +530,7 @@ BGP_MSG_T = {
 dl += [BGP_MSG_T]
 
 @enum.unique
-class BgpMsgT(BaseEnum):
+class BgpMsgT(_BaseEnum):
     """BGP Message Types. Defined in RFC4271."""
     reserved = 0
     open = 1
@@ -554,7 +554,7 @@ BGP_ERR_C = {
 dl += [BGP_ERR_C]
 
 @enum.unique
-class BgpErrC(BaseEnum):
+class BgpErrC(_BaseEnum):
     """BGP Error Codes. Defined in RFC4271."""
     reserved = (0,
         "Reserved")
@@ -583,7 +583,7 @@ BGP_HDR_ERR_SC = {
 dl += [BGP_HDR_ERR_SC]
 
 @enum.unique
-class BgpHdrErrSc(BaseEnum):
+class BgpHdrErrSc(_BaseEnum):
     """BGP Message Header Error Subcodes. Defined in RFC4271."""
     reserved = 0
     connection_not_sync = 1
@@ -610,7 +610,7 @@ BGP_OPEN_ERR_SC = {
 dl += [BGP_OPEN_ERR_SC]
 
 @enum.unique
-class BgpOpenErrSc(BaseEnum):
+class BgpOpenErrSc(_BaseEnum):
     """OPEN Message Error Subcodes. Defined in RFC4271."""
     reserved = (0,
         "Reserved")
@@ -649,7 +649,7 @@ BGP_UPDATE_ERR_SC = {
 dl += [BGP_UPDATE_ERR_SC]
 
 @enum.unique
-class BgpUpdateErrSc(BaseEnum):
+class BgpUpdateErrSc(_BaseEnum):
     """UPDATE Message Error Subcodes. Defined in RFC4271."""
     reserved = (0,
         "Reserved")
@@ -688,7 +688,7 @@ BGP_FSM_ERR_SC = {
 dl += [BGP_FSM_ERR_SC]
 
 @enum.unique
-class BgpFsmErrSc(BaseEnum):
+class BgpFsmErrSc(_BaseEnum):
     """BGP Finite State Machine Error Subcodes. Defined in RFC6608."""
     unspecified_err = (0,
         "Unspecified Error")
@@ -716,7 +716,7 @@ BGP_CEASE_ERR_SC = {
 dl += [BGP_CEASE_ERR_SC]
 
 @enum.unique
-class BgpCeaseErrSc(BaseEnum):
+class BgpCeaseErrSc(_BaseEnum):
     """BGP Cease NOTIFICATION Message Subcodes. Defined in RFC4486."""
     reserved = (0,
         "Reserved")
@@ -748,7 +748,7 @@ BGP_ERR_SC = {
     6:BGP_CEASE_ERR_SC,
 }
 
-class BgpErrSc(BaseEnum):
+class BgpErrSc(_BaseEnum):
     """BGP Error Subcodes."""
     bgp_hdr_err_sc = 1
     bgp_update_err_sc2 = 2
@@ -775,7 +775,7 @@ BGP_OPT_PARAMS_T = {
 dl += [BGP_OPT_PARAMS_T]
 
 @enum.unique
-class BgpOptParamsT(BaseEnum):
+class BgpOptParamsT(_BaseEnum):
     """BGP OPEN Optional Parameter Types. Defined in RFC5492."""
     reserved = 0
     authentication = 1 # Deprecated
@@ -803,7 +803,7 @@ BGP_CAP_C = {
 dl += [BGP_CAP_C]
 
 @enum.unique
-class BgpCapC(BaseEnum):
+class BgpCapC(_BaseEnum):
     """Capability Codes. Defined in RFC5492."""
     reserved = (0,
         "Reserved")
@@ -843,7 +843,7 @@ ORF_T = {
 dl += [ORF_T]
 
 @enum.unique
-class OrfT(BaseEnum):
+class OrfT(_BaseEnum):
     """Outbound Route Filtering Capability. Defined in RFC5291."""
     address_prefix_orf = (64, # Defined in RFC5292
         "Address Prefix ORF")
@@ -857,7 +857,7 @@ ORF_SEND_RECV = {
 dl += [ORF_SEND_RECV]
 
 @enum.unique
-class OrfSendRecv(BaseEnum):
+class OrfSendRecv(_BaseEnum):
     receive = 1
     send = 2
     both = 3
@@ -872,7 +872,7 @@ AS_REP = {
 dl += [AS_REP]
 
 @enum.unique
-class AsRep(BaseEnum):
+class AsRep(_BaseEnum):
     """AS Number Representation."""
     asplain = 1
     asdot_plus = 2
@@ -1282,15 +1282,15 @@ class OptParams(Base):
         self.cap_type = BgpCapC(self.val_num(buf, 1))
         self.cap_len = self.val_num(buf, 1)
 
-        if self.cap_type == BGP_CAP_C['Multiprotocol Extensions for BGP-4']:
+        if self.cap_type == BgpCapC.multiproto_extensions_bgp_4:
             self.unpack_multi_ext(buf)
-        elif self.cap_type == BGP_CAP_C['Route Refresh Capability for BGP-4']:
+        elif self.cap_type == BgpCapC.route_refresh_cap_bgp_4:
             self.p += self.len - 2
-        elif self.cap_type == BGP_CAP_C['Outbound Route Filtering Capability']:
+        elif self.cap_type == BgpCapC.outbound_route_filtering_cap:
             self.unpack_orf(buf)
-        elif self.cap_type == BGP_CAP_C['Graceful Restart Capability']:
+        elif self.cap_type == BgpCapC.graceful_restart_cap:
             self.unpack_graceful_restart(buf)
-        elif self.cap_type == BGP_CAP_C['Support for 4-octet AS number capability']:
+        elif self.cap_type == BgpCapC.support_4_octet_as_numb_cap:
             self.unpack_support_as4(buf)
         else:
             self.p += self.len - 2

--- a/mrtparse.py
+++ b/mrtparse.py
@@ -31,12 +31,25 @@ signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
 # mrtparse information
 __pyname__  = 'mrtparse'
-__version__ =  '1.2'
+__version__ = '1.2'
 __descr__   = 'parse a MRT-format data'
 __url__     = 'https://github.com/YoshiyukiYamauchi/mrtparse'
 __author__  = 'Tetsumune KISO, Yoshiyuki YAMAUCHI, Nobuhiro ITOU'
 __email__   = 't2mune@gmail.com, info@greenhippo.co.jp, js333123@gmail.com'
 __license__ = 'Apache License, Version 2.0'
+__all__     = (['Reader'] +
+               ['AFI_T', 'SAFI_T', 'MSG_T', 'BGP_ST', 'TD_ST', 'TD_V2_ST',
+                'BGP4MP_ST', 'MSG_ST', 'BGP_FSM', 'BGP_ATTR_T', 'ORIGIN_T',
+                'AS_PATH_SEG_T', 'COMM_T', 'BGP_MSG_T', 'BGP_ERR_C',
+                'BGP_HDR_ERR_SC', 'BGP_OPEN_ERR_SC', 'BGP_UPDATE_ERR_SC',
+                'BGP_FSM_ERR_SC', 'BGP_CEASE_ERR_SC', 'BGP_OPT_PARAMS_T',
+                'BGP_CAP_C', 'ORF_T', 'ORF_SEND_RECV', 'AS_REP'] +
+               ['AfiT', 'SafiT', 'MsgT', 'BgpSt', 'TdSt', 'TdV2St',
+                'Bgp4mpSt', 'MsgSt', 'BgpFsm', 'BgpAttrT', 'OriginT',
+                'AsPathSegT', 'CommT', 'BgpMsgT', 'BgpErrC',
+                'BgpHdrErrSc', 'BgpOpenErrSc', 'BgpUpdateErrSc',
+                'BgpFsmErrSc', 'BgpCeaseErrSc', 'BgpOptParamsT', 'BgpCapC',
+                'OrfT', 'OrfSendRecv', 'AsRep'])
 
 # Magic Number
 GZIP_MAGIC = b'\x1f\x8b'

--- a/mrtparse.py
+++ b/mrtparse.py
@@ -96,8 +96,22 @@ class FillEnum(object):
         return new_enum_cls
 
 class BaseEnum(int, enum.Enum):
-    """This class provides __str__ and __repr__ for Type and Code Enums."""
+    """This class is the abstract Base for Type and Code Enums here.
+
+    It Provides a customized __str__ and __repr__ string prints.
+    It overwrites the __new__ method to allow tuple as input.
+
+    Args:
+        value: The associated value to the member. Must be a subclass of int.
+        nice (optional): A for humans nice readable and short description.
+    """
     __metaclass__ = ABCMeta
+
+    def __new__(cls, value, nice=None):
+        obj = int.__new__(cls, value)
+        obj._value_ = value
+        obj.nice = nice
+        return obj
 
     def __str__(self):
         return (str(self.value) +
@@ -392,45 +406,40 @@ class BgpAttrT(BaseEnum):
     local_pref = 5
     atomic_aggregate = 6
     aggregator = 7
-    community = 8                   # Defined in RFC1997
-    originator_id = 9               # Defined in RFC4456
-    cluster_list = 10               # Defined in RFC4456
-    dpa = 11                        # Deprecated in RFC6938
-    advertiser = 12                 # Deprecated in RFC6938
-    rcid_path_cluster_id = 13       # Deprecated in RFC6938
-    mp_reach_nlri = 14              # Defined in RFC4760
-    mp_unreach_nlri = 15            # Defined in RFC4760
-    extended_communities = 16       # Defined in RFC4360
-    as4_path = 17                   # Defined in RFC6793
-    as4_aggregator = 18             # Defined in RFC6793
+    community = 8                      # Defined in RFC1997
+    originator_id = 9                  # Defined in RFC4456
+    cluster_list = 10                  # Defined in RFC4456
+    dpa = 11                           # Deprecated in RFC6938
+    advertiser = 12                    # Deprecated in RFC6938
+    rcid_path_cluster_id = 13          # Deprecated in RFC6938
+    mp_reach_nlri = 14                 # Defined in RFC4760
+    mp_unreach_nlri = 15               # Defined in RFC4760
+    extended_communities = 16          # Defined in RFC4360
+    as4_path = 17                      # Defined in RFC6793
+    as4_aggregator = 18                # Defined in RFC6793
     # Deprecated in [Gargi_Nalawade][draft-kapoor-nalawade-idr-bgp-ssa-00]
     #     [draft-nalawade-idr-mdt-safi-00][draft-wijnands-mt-discovery-00]
-    safi_specific_attr = 19
-    connector_attr = 20             # Deprecated in RFC6037
-    as_pathlimit = 21               # Deprecated in [draft-ietf-idr-as-pathlimit]
-    pmsi_tunnel = 22                # Defined in RFC6514
-    tunnel_encapsulation_attr = 23  # Defined in RFC5512
-    traffic_engineering = 24        # Defined in RFC5543
-    ipv6_addr_specific_ext_comm = 25# Defined in RFC5701
-    aigp = 26                       # Defined in RFC7311
-    pe_distinguisher_labels = 27    # Defined in RFC6514
-    bgp_entropy_label_cap_attr = 28 # Deprecated in RFC6790, RFC7447
+    safi_specific_attr = (19,
+        "SAFI Specific Attribute (SSA) (deprecated)")
+    connector_attr = (20,              # Deprecated in RFC6037
+        "Connector Attribute (deprecated)")
+    as_pathlimit = (21,           # Deprecated in [draft-ietf-idr-as-pathlimit]
+        "AS_PATHLIMIT (deprecated)")
+    pmsi_tunnel = 22                   # Defined in RFC6514
+    tunnel_encapsulation_attr = (23,   # Defined in RFC5512
+        "Tunnel Encapsulation Attribute")
+    traffic_engineering = 24           # Defined in RFC5543
+    ipv6_addr_specific_ext_comm = (25, # Defined in RFC5701
+        "IPv6 Address Specific Extended Community")
+    aigp = 26                          # Defined in RFC7311
+    pe_distinguisher_labels = 27       # Defined in RFC6514
+    bgp_entropy_label_cap_attr = (28,  # Deprecated in RFC6790, RFC7447
+        "BGP Entropy Label Capability Attribute (deprecated)")
     # Defined in [draft-ietf-idr-ls-distribution]
     # (TEMPORARY - registered 2014-03-11, expires 2016-03-11)
-    bgp_ls_attr = 29
-    attr_set = 128                  # Defined in RFC6368
-
-BgpAttrT.safi_specific_attr.nice = "SAFI Specific Attribute (SSA) (deprecated)"
-BgpAttrT.connector_attr.nice = "Connector Attribute (deprecated)"
-BgpAttrT.as_pathlimit.nice = "AS_PATHLIMIT (deprecated)"
-BgpAttrT.tunnel_encapsulation_attr.nice = "Tunnel Encapsulation Attribute"
-BgpAttrT.ipv6_addr_specific_ext_comm.nice = (
-    "IPv6 Address Specific Extended Community")
-BgpAttrT.bgp_entropy_label_cap_attr.nice = (
-    "BGP Entropy Label Capability Attribute (deprecated)")
-BgpAttrT.bgp_ls_attr.nice = (
-    "BGP-LS Attribute (TEMPORARY - registered 2014-03-11, expires 2016-03-11)")
-
+    bgp_ls_attr = (29,
+        "BGP-LS Attribute (TEMPORARY - registered 2014-03-11, expires 2016-03-11)")
+    attr_set = 128                     # Defined in RFC6368
 
 
 # BGP ORIGIN Types
@@ -534,21 +543,21 @@ dl += [BGP_ERR_C]
 @enum.unique
 class BgpErrC(BaseEnum):
     """BGP Error Codes. Defined in RFC4271."""
-    reserved = 0
-    msg_header_err = 1
-    open_msg_err = 2
-    update_msg_err = 3
-    hold_timer_expired = 4
-    finite_state_machine_err = 5
-    cease = 6
+    reserved = (0,
+        "Reserved")
+    msg_header_err = (1,
+        "Message Header Error")
+    open_msg_err = (2,
+        "OPEN Message Error")
+    update_msg_err = (3,
+        "UPDATE Message Error")
+    hold_timer_expired = (4,
+        "Hold Timer Expired")
+    finite_state_machine_err = (5,
+        "Finite State Machine Error")
+    cease = (6,
+        "Cease")
 
-BgpErrC.reserved.nice = "Reserved"
-BgpErrC.msg_header_err.nice = "Message Header Error"
-BgpErrC.open_msg_err.nice = "OPEN Message Error"
-BgpErrC.update_msg_err.nice = "UPDATE Message Error"
-BgpErrC.hold_timer_expired.nice = "Hold Timer Expired"
-BgpErrC.finite_state_machine_err.nice = "Finite State Machine Error"
-BgpErrC.cease.nice = "Cease"
 
 # BGP Message Header Error Subcodes
 # Defined in RFC4271
@@ -590,23 +599,23 @@ dl += [BGP_OPEN_ERR_SC]
 @enum.unique
 class BgpOpenErrSc(BaseEnum):
     """OPEN Message Error Subcodes. Defined in RFC4271."""
-    reserved = 0
-    unsupported_vers_numb = 1
-    bad_peer_as = 2
-    bad_bgp_id = 3
-    unsupported_opt_parameter = 4
-    deprecated = 5
-    unacceptable_hold_time = 6
-    unsupported_capability = 7         # Defined in RFC5492
+    reserved = (0,
+        "Reserved")
+    unsupported_vers_numb = (1,
+        "Unsupported Version Number")
+    bad_peer_as = (2,
+        "Bad Peer AS")
+    bad_bgp_id = (3,
+        "Bad BGP Identifier")
+    unsupported_opt_parameter = (4,
+        "Unsupported Optional Parameter")
+    deprecated = (5,
+        "[Deprecated]")
+    unacceptable_hold_time = (6,
+        "Unacceptable Hold Time")
+    unsupported_capability = (7,       # Defined in RFC5492
+        "Unsupported Capability")
 
-BgpOpenErrSc.reserved.nice = "Reserved"
-BgpOpenErrSc.unsupported_vers_numb.nice = "Unsupported Version Number"
-BgpOpenErrSc.bad_peer_as.nice = "Bad Peer AS"
-BgpOpenErrSc.bad_bgp_id.nice = "Bad BGP Identifier"
-BgpOpenErrSc.unsupported_opt_parameter.nice = "Unsupported Optional Parameter"
-BgpOpenErrSc.deprecated.nice = "[Deprecated]"
-BgpOpenErrSc.unacceptable_hold_time.nice = "Unacceptable Hold Time"
-BgpOpenErrSc.unsupported_capability.nice = "Unsupported Capability"
 
 # UPDATE Message Error Subcodes
 # Defined in RFC4271
@@ -629,32 +638,31 @@ dl += [BGP_UPDATE_ERR_SC]
 @enum.unique
 class BgpUpdateErrSc(BaseEnum):
     """UPDATE Message Error Subcodes. Defined in RFC4271."""
-    reserved = 0
-    malformed_attr_list = 1
-    unrecognized_well_known_attr = 2
-    missing_well_known_attr = 3
-    attr_flags_err = 4
-    attr_length_err = 5
-    invalid_origin_attr = 6
-    deprecated = 7
-    invalid_next_hop_attr = 8
-    optional_attr_err = 9
-    invalid_network_field = 10
-    malformed_as_path = 11
+    reserved = (0,
+        "Reserved")
+    malformed_attr_list = (1,
+        "Malformed Attribute List")
+    unrecognized_well_known_attr = (2,
+        "Unrecognized Well-known Attribute")
+    missing_well_known_attr = (3,
+        "Missing Well-known Attribute")
+    attr_flags_err = (4,
+        "Attribute Flags Error")
+    attr_length_err = (5,
+        "Attribute Length Error")
+    invalid_origin_attr = (6,
+        "Invalid ORIGIN Attribute")
+    deprecated = (7,
+        "[Deprecated]")
+    invalid_next_hop_attr = (8,
+        "Invalid NEXT_HOP Attribute")
+    optional_attr_err = (9,
+        "Optional Attribute Error")
+    invalid_network_field = (10,
+        "Invalid Network Field")
+    malformed_as_path = (11,
+        "Malformed AS_PATH")
 
-BgpUpdateErrSc.reserved.nice = "Reserved"
-BgpUpdateErrSc.malformed_attr_list.nice = "Malformed Attribute List"
-BgpUpdateErrSc.unrecognized_well_known_attr.nice = (
-    "Unrecognized Well-known Attribute")
-BgpUpdateErrSc.missing_well_known_attr.nice = "Missing Well-known Attribute"
-BgpUpdateErrSc.attr_flags_err.nice = "Attribute Flags Error"
-BgpUpdateErrSc.attr_length_err.nice = "Attribute Length Error"
-BgpUpdateErrSc.invalid_origin_attr.nice = "Invalid ORIGIN Attribute"
-BgpUpdateErrSc.deprecated.nice = "[Deprecated]"
-BgpUpdateErrSc.invalid_next_hop_attr.nice = "Invalid NEXT_HOP Attribute"
-BgpUpdateErrSc.optional_attr_err.nice = "Optional Attribute Error"
-BgpUpdateErrSc.invalid_network_field.nice = "Invalid Network Field"
-BgpUpdateErrSc.malformed_as_path.nice = "Malformed AS_PATH"
 
 # BGP Finite State Machine Error Subcodes
 # Defined in RFC6608
@@ -669,18 +677,15 @@ dl += [BGP_FSM_ERR_SC]
 @enum.unique
 class BgpFsmErrSc(BaseEnum):
     """BGP Finite State Machine Error Subcodes. Defined in RFC6608."""
-    unspecified_err = 0
-    rcv_unexp_msg_in_opensent = 1
-    rcv_unexp_msg_in_openconfirm = 2
-    rcv_unexp_msg_in_established = 3
+    unspecified_err = (0,
+        "Unspecified Error")
+    rcv_unexp_msg_in_opensent = (1,
+        "Receive Unexpected Message in OpenSent State")
+    rcv_unexp_msg_in_openconfirm = (2,
+        "Receive Unexpected Message in OpenConfirm State")
+    rcv_unexp_msg_in_established = (3,
+        "Receive Unexpected Message in Established State")
 
-BgpFsmErrSc.unspecified_err.nice = "Unspecified Error"
-BgpFsmErrSc.rcv_unexp_msg_in_opensent.nice = (
-    "Receive Unexpected Message in OpenSent State")
-BgpFsmErrSc.rcv_unexp_msg_in_openconfirm.nice = (
-    "Receive Unexpected Message in OpenConfirm State")
-BgpFsmErrSc.rcv_unexp_msg_in_established.nice = (
-    "Receive Unexpected Message in Established State")
 
 # BGP Cease NOTIFICATION Message Subcodes
 # Defined in RFC4486
@@ -700,27 +705,24 @@ dl += [BGP_CEASE_ERR_SC]
 @enum.unique
 class BgpCeaseErrSc(BaseEnum):
     """BGP Cease NOTIFICATION Message Subcodes. Defined in RFC4486."""
-    reserved = 0
-    max_numb_of_prefixes_reached = 1
-    administrative_shutdown = 2
-    peer_de_configured = 3
-    administrative_reset = 4
-    connection_rejected = 5
-    other_configuration_change = 6
-    connection_collision_resolution = 7
-    out_of_resources = 8
-
-BgpCeaseErrSc.reserved.nice = "Reserved"
-BgpCeaseErrSc.max_numb_of_prefixes_reached.nice = (
-    "Maximum Number of Prefixes Reached")
-BgpCeaseErrSc.administrative_shutdown.nice = "Administrative Shutdown"
-BgpCeaseErrSc.peer_de_configured.nice = "Peer De-configured"
-BgpCeaseErrSc.administrative_reset.nice = "Administrative Reset"
-BgpCeaseErrSc.connection_rejected.nice = "Connection Rejected"
-BgpCeaseErrSc.other_configuration_change.nice = "Other Configuration Change"
-BgpCeaseErrSc.connection_collision_resolution.nice = (
-    "Connection Collision Resolution")
-BgpCeaseErrSc.out_of_resources.nice = "Out of Resources"
+    reserved = (0,
+        "Reserved")
+    max_numb_of_prefixes_reached = (1,
+        "Maximum Number of Prefixes Reached")
+    administrative_shutdown = (2,
+        "Administrative Shutdown")
+    peer_de_configured = (3,
+        "Peer De-configured")
+    administrative_reset = (4,
+        "Administrative Reset")
+    connection_rejected = (5,
+        "Connection Rejected")
+    other_configuration_change = (6,
+        "Other Configuration Change")
+    connection_collision_resolution = (7,
+        "Connection Collision Resolution")
+    out_of_resources = (8,
+        "Out of Resources")
 
 
 # BGP Error Subcodes
@@ -790,41 +792,34 @@ dl += [BGP_CAP_C]
 @enum.unique
 class BgpCapC(BaseEnum):
     """Capability Codes. Defined in RFC5492."""
-    reserved = 0
-    multiproto_extensions_bgp_4 = 1      # Defined in RFC2858
-    route_refresh_cap_bgp_4 = 2          # Defined in RFC2918
-    outbound_route_filtering_cap = 3     # Defined in RFC5291
-    multiple_routes_to_a_dest_cap = 4    # Defined in RFC3107
-    extended_next_hop_encoding = 5       # Defined in RFC5549
-    graceful_restart_cap = 64            # Defined in RFC4724
-    support_4_octet_as_numb_cap = 65     # Defined in RFC6793
-    deprecated = 66
-    support_for_dynamic_cap = 67         # draft-ietf-idr-dynamic-cap
-    multisession_bgp_cap = 68            # draft-ietf-idr-bgp-multisession
-    add_path_cap = 69                    # draft-ietf-idr-add-paths
-    enhanced_route_refresh_cap = 70      # draft-keyur-bgp-enhanced-route-refresh
-    long_lived_graceful_restart_cap = 71 # draft-uttaro-idr-bgp-persistence
-
-BgpCapC.reserved.nice = "Reserved"
-BgpCapC.multiproto_extensions_bgp_4.nice = "Multiprotocol Extensions for BGP-4"
-BgpCapC.route_refresh_cap_bgp_4.nice = (
-    "Route Refresh Capability for BGP-4")
-BgpCapC.outbound_route_filtering_cap.nice = (
-    "Outbound Route Filtering Capability")
-BgpCapC.multiple_routes_to_a_dest_cap.nice = (
-    "Multiple routes to a destination capability")
-BgpCapC.extended_next_hop_encoding.nice = "Extended Next Hop Encoding"
-BgpCapC.graceful_restart_cap.nice = "Graceful Restart Capability"
-BgpCapC.support_4_octet_as_numb_cap.nice = (
-    "Support for 4-octet AS number capability")
-BgpCapC.deprecated.nice = "[Deprecated]"
-BgpCapC.support_for_dynamic_cap.nice = (
-    "Support for Dynamic Capability (capability specific)")
-BgpCapC.multisession_bgp_cap.nice = "Multisession BGP Capability"
-BgpCapC.add_path_cap.nice = "ADD-PATH Capability"
-BgpCapC.enhanced_route_refresh_cap.nice = "Enhanced Route Refresh Capability"
-BgpCapC.long_lived_graceful_restart_cap.nice = (
-    "Long-Lived Graceful Restart (LLGR) Capability")
+    reserved = (0,
+        "Reserved")
+    multiproto_extensions_bgp_4 = (1,      # Defined in RFC2858
+        "Multiprotocol Extensions for BGP-4")
+    route_refresh_cap_bgp_4 = (2,          # Defined in RFC2918
+        "Route Refresh Capability for BGP-4")
+    outbound_route_filtering_cap = (3,     # Defined in RFC5291
+        "Outbound Route Filtering Capability")
+    multiple_routes_to_a_dest_cap = (4,    # Defined in RFC3107
+        "Multiple routes to a destination capability")
+    extended_next_hop_encoding = (5,       # Defined in RFC5549
+        "Extended Next Hop Encoding")
+    graceful_restart_cap = (64,            # Defined in RFC4724
+        "Graceful Restart Capability")
+    support_4_octet_as_numb_cap = (65,     # Defined in RFC6793
+        "Support for 4-octet AS number capability")
+    deprecated = (66,
+        "[Deprecated]")
+    support_for_dynamic_cap = (67,         # draft-ietf-idr-dynamic-cap
+        "Support for Dynamic Capability (capability specific)")
+    multisession_bgp_cap = (68,            # draft-ietf-idr-bgp-multisession
+        "Multisession BGP Capability")
+    add_path_cap = (69,                    # draft-ietf-idr-add-paths
+        "ADD-PATH Capability")
+    enhanced_route_refresh_cap = (70,      # draft-keyur-bgp-enhanced-route-refresh
+        "Enhanced Route Refresh Capability")
+    long_lived_graceful_restart_cap = (71, # draft-uttaro-idr-bgp-persistence
+        "Long-Lived Graceful Restart (LLGR) Capability")
 
 
 # Outbound Route Filtering Capability
@@ -837,9 +832,8 @@ dl += [ORF_T]
 @enum.unique
 class OrfT(BaseEnum):
     """Outbound Route Filtering Capability. Defined in RFC5291."""
-    address_prefix_orf = 64 # Defined in RFC5292
-
-OrfT.address_prefix_orf.nice = "Address Prefix ORF"
+    address_prefix_orf = (64, # Defined in RFC5292
+        "Address Prefix ORF")
 
 
 ORF_SEND_RECV = {

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,11 @@
 
 from distutils.core import setup
 import mrtparse
+import sys
+
+requirements_list = []
+if sys.version_info < (3, 4):
+    requirements_list = ['enum34']
 
 setup(
     name=mrtparse.__pyname__,
@@ -12,4 +17,5 @@ setup(
     author_email=mrtparse.__email__,
     license=mrtparse.__license__,
     py_modules=[mrtparse.__pyname__],
+    install_requires=requirements_list,
 )


### PR DESCRIPTION
Quite the same MR as #5 except that the possible missing values are not filled up. Instead they are created on demand.

See #5 for discussion. and here is description from it:

> Overwrite **new** and create a new ENUM with only a single value if a value not in the enum is requested. You had to create a new Enum every time, because they are singletons and can't be modified after creation. Works well and is simple in use, but you have then multiple Enum classes for every new value. Not nice, but would be ok, since it is only for more fault tolerance.
