### PR TITLE
Fix - extra triple quote in mrt2exabgp

### DIFF
--- a/examples/mrt2exabgp.py
+++ b/examples/mrt2exabgp.py
@@ -108,7 +108,7 @@ def parse_args():
         help='convert IPv4 entries and change IPv4 next-hop if specified')
     p.add_argument(
         '-6', type=str, nargs='?', metavar='NEXT_HOP', dest='next_hop6',
-        help='convert IPv6 entries and change IPv6 next-hop if specified''')
+        help='convert IPv6 entries and change IPv6 next-hop if specified')
     p.add_argument(
         '-a', default=False, action='store_true',
         help='convert all entries \


### PR DESCRIPTION
It seems to be correctly interpreted in Python, but it confuses Emacs
syntax highlighting.